### PR TITLE
print friendly warning when running in invalid directory

### DIFF
--- a/java17/src/main/java/io/papermc/paperclip/Paperclip.java
+++ b/java17/src/main/java/io/papermc/paperclip/Paperclip.java
@@ -18,6 +18,11 @@ import java.util.Map;
 public final class Paperclip {
 
     public static void main(final String[] args) {
+        if (Path.of("").toAbsolutePath().toString().contains("!")) {
+            System.err.println("Paperclip may not run in a directory containing '!'. Please rename the affected folder.");
+            System.exit(1);
+        }
+
         final URL[] classpathUrls = setupClasspath();
 
         final ClassLoader parentClassLoader = Paperclip.class.getClassLoader().getParent();


### PR DESCRIPTION
Better closes #31 and others. Currently running in a directory containing either "!" would cause:

```
Exception in thread "main" java.lang.IllegalArgumentException
        at java.instrument/sun.instrument.InstrumentationImpl.appendToClassLoaderSearch0(Native Method)
        at java.instrument/sun.instrument.InstrumentationImpl.appendToSystemClassLoaderSearch(InstrumentationImpl.java:224)
        at io.papermc.paperclip.Agent.addToClassPath(Agent.java:38)
        at io.papermc.paperclip.Paperclip.getMainMethod(Paperclip.java:216)
        at io.papermc.paperclip.Paperclip.main(Paperclip.java:42)
```
or

```
Exception in thread "main" java.lang.NullPointerException: No patch.properties file found inside paperclip jar
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at io.papermc.paperclip.Paperclip.setupEnv(Paperclip.java:70)
	at io.papermc.paperclip.Paperclip.main(Paperclip.java:40)
```

Or now with 1.18:
```
Starting null
Exception in thread "ServerMain" java.lang.NullPointerException
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:467)
	at io.papermc.paperclip.Paperclip.lambda$main$0(Paperclip.java:31)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

depending on version.