### PR TITLE
fix NPE if no patches were found

### DIFF
--- a/java17/src/main/java/io/papermc/paperclip/FileEntry.java
+++ b/java17/src/main/java/io/papermc/paperclip/FileEntry.java
@@ -55,12 +55,10 @@ record FileEntry(byte[] hash, String id, String path) {
         final String baseDir,
         final Path outputDir
     ) throws IOException {
-        if (patches != null) {
-            for (final PatchEntry patch : patches) {
-                if (patch.location().equals(targetName) && patch.outputPath().equals(this.path)) {
-                    // This file will be created from a patch
-                    return;
-                }
+        for (final PatchEntry patch : patches) {
+            if (patch.location().equals(targetName) && patch.outputPath().equals(this.path)) {
+                // This file will be created from a patch
+                return;
             }
         }
 

--- a/java17/src/main/java/io/papermc/paperclip/FileEntry.java
+++ b/java17/src/main/java/io/papermc/paperclip/FileEntry.java
@@ -55,10 +55,12 @@ record FileEntry(byte[] hash, String id, String path) {
         final String baseDir,
         final Path outputDir
     ) throws IOException {
-        for (final PatchEntry patch : patches) {
-            if (patch.location().equals(targetName) && patch.outputPath().equals(this.path)) {
-                // This file will be created from a patch
-                return;
+        if (patches != null) {
+            for (final PatchEntry patch : patches) {
+                if (patch.location().equals(targetName) && patch.outputPath().equals(this.path)) {
+                    // This file will be created from a patch
+                    return;
+                }
             }
         }
 

--- a/java17/src/main/java/io/papermc/paperclip/Paperclip.java
+++ b/java17/src/main/java/io/papermc/paperclip/Paperclip.java
@@ -53,7 +53,7 @@ public final class Paperclip {
 
         final PatchEntry[] patches = findPatches();
         final DownloadContext downloadContext = findDownloadContext();
-        if (patches != null && downloadContext == null) {
+        if (patches.length > 0 && downloadContext == null) {
             throw new IllegalArgumentException("patches.list file found without a corresponding original-url file");
         }
 
@@ -91,7 +91,7 @@ public final class Paperclip {
     private static PatchEntry[] findPatches() {
         final InputStream patchListStream = Paperclip.class.getResourceAsStream("/META-INF/patches.list");
         if (patchListStream == null) {
-            return null;
+            return new PatchEntry[0];
         }
 
         try (patchListStream) {
@@ -145,7 +145,7 @@ public final class Paperclip {
     }
 
     private static Map<String, Map<String, URL>> extractAndApplyPatches(final Path originalJar, final PatchEntry[] patches, final Path repoDir) {
-        if (originalJar == null && patches != null) {
+        if (originalJar == null && patches.length > 0) {
             throw new IllegalArgumentException("Patch data found without patch target");
         }
 
@@ -224,7 +224,7 @@ public final class Paperclip {
         final Path originalJar,
         final Path repoDir
     ) {
-        if (patches == null) {
+        if (patches.length == 0) {
             return;
         }
         if (originalJar == null) {


### PR DESCRIPTION
If the better fix is to have the findPatches method in Paperclip return a 0-length array, that can be done too, I just noticed this while trying to run the jar from paperweight's createReobfBundlerJar task.