### PR TITLE
Simplify java version checking

### DIFF
--- a/java6/src/main/java/io/papermc/paperclip/Main.java
+++ b/java6/src/main/java/io/papermc/paperclip/Main.java
@@ -14,7 +14,8 @@ import java.lang.reflect.Method;
 public final class Main {
 
     public static void main(final String[] args) {
-        if (getJavaVersion() < 17) {
+        float javaVersion = Float.parseFloat(System.getProperty("java.class.version"));
+        if (javaVersion < 61f) {
             System.err.println("Minecraft 1.18 requires running the server with Java 17 or above. " +
                 "Download Java 17 (or above) from https://adoptium.net/");
             System.exit(1);
@@ -26,25 +27,6 @@ public final class Main {
             mainMethod.invoke(null, (Object) args);
         } catch (final Exception e) {
             e.printStackTrace();
-        }
-    }
-
-    private static int getJavaVersion() {
-        final String version = System.getProperty("java.version");
-        final String[] parts = version.split("\\.");
-
-        final String errorMsg = "Could not determine version of the current JVM";
-        if (parts.length == 0) {
-            throw new IllegalStateException(errorMsg);
-        }
-
-        if (parts[0].equals("1")) {
-            if (parts.length < 2) {
-                throw new IllegalStateException(errorMsg);
-            }
-            return Integer.parseInt(parts[1]);
-        } else {
-            return Integer.parseInt(parts[0]);
         }
     }
 }

--- a/java6/src/main/java/io/papermc/paperclip/Main.java
+++ b/java6/src/main/java/io/papermc/paperclip/Main.java
@@ -14,8 +14,7 @@ import java.lang.reflect.Method;
 public final class Main {
 
     public static void main(final String[] args) {
-        float javaVersion = Float.parseFloat(System.getProperty("java.class.version"));
-        if (javaVersion < 61f) {
+        if (getJavaVersion() < 17) {
             System.err.println("Minecraft 1.18 requires running the server with Java 17 or above. " +
                 "Download Java 17 (or above) from https://adoptium.net/");
             System.exit(1);
@@ -28,5 +27,17 @@ public final class Main {
         } catch (final Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private static int getJavaVersion() {
+        final String version = System.getProperty("java.class.version");
+        final String[] parts = version.split("\\.");
+
+        if (parts.length == 0) {
+            throw new IllegalStateException("Could not determine version of the current JVM");
+        }
+
+        // class file versions: 1.1 = 45, 1.2 = 46, ..., 18 = 62
+        return Integer.parseInt(parts[0]) - 44;
     }
 }


### PR DESCRIPTION
This also resolves issues when running with a newer java version than 17. (In my case 18-ea) which results in an exception when starting: `Exception in thread "main" java.lang.NumberFormatException: For input string: "18-ea"`