### PR TITLE
Extract java version from specification version

### DIFF
--- a/java6/src/main/java/io/papermc/paperclip/Main.java
+++ b/java6/src/main/java/io/papermc/paperclip/Main.java
@@ -30,7 +30,7 @@ public final class Main {
     }
 
     private static int getJavaVersion() {
-        final String version = System.getProperty("java.version");
+        final String version = System.getProperty("java.specification.version");
         final String[] parts = version.split("\\.");
 
         final String errorMsg = "Could not determine version of the current JVM";


### PR DESCRIPTION
Fixes #45.

As already mentioned in #44, the `java.specification.version` property is better suited to extract the major version from.