### PR TITLE
Fix issue with -classpath arguments being ignored on Java 17

### DIFF
--- a/java17/src/main/java/io/papermc/paperclip/Paperclip.java
+++ b/java17/src/main/java/io/papermc/paperclip/Paperclip.java
@@ -27,7 +27,7 @@ public final class Paperclip {
 
         final URL[] classpathUrls = setupClasspath();
 
-        final ClassLoader parentClassLoader = Paperclip.class.getClassLoader().getParent();
+        final ClassLoader parentClassLoader = Paperclip.class.getClassLoader();
         final URLClassLoader classLoader = new URLClassLoader(classpathUrls, parentClassLoader);
 
         final String mainClassName = findMainClass();


### PR DESCRIPTION
Following code has been tested by compiling Paperclip and replacing classes in Paper jar with resulting new classes.