### PR TITLE
use system cache directory for cache

### DIFF
--- a/java17/build.gradle.kts
+++ b/java17/build.gradle.kts
@@ -21,11 +21,12 @@ repositories {
 
 dependencies {
     implementation("io.sigpipe:jbsdiff:1.0")
+    implementation("dev.dirs:directories:26")
 }
 
 tasks.shadowJar {
     val prefix = "paperclip.libs"
-    listOf("org.apache", "org.tukaani", "io.sigpipe").forEach { pack ->
+    listOf("org.apache", "org.tukaani", "io.sigpipe", "dev.dirs").forEach { pack ->
         relocate(pack, "$prefix.$pack")
     }
 

--- a/java17/src/main/java/io/papermc/paperclip/Paperclip.java
+++ b/java17/src/main/java/io/papermc/paperclip/Paperclip.java
@@ -1,5 +1,7 @@
 package io.papermc.paperclip;
 
+import dev.dirs.ProjectDirectories;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,10 +14,10 @@ import java.net.URLClassLoader;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public final class Paperclip {
 
@@ -49,7 +51,10 @@ public final class Paperclip {
     }
 
     private static URL[] setupClasspath() {
-        final var repoDir = Path.of(System.getProperty("bundlerRepoDir", ""));
+        final var repoDir = Path.of(Objects.requireNonNullElse(
+            System.getProperty("bundlerRepoDir", ProjectDirectories.from("io", "papermc", "paperclip").cacheDir),
+            ""
+        ));
 
         final PatchEntry[] patches = findPatches();
         final DownloadContext downloadContext = findDownloadContext();


### PR DESCRIPTION
## Rational

There is conversation in `paper-help` discord channels that make me this idea.
This has two reasons for me creating this merge request:
1. If you have multiple installations of paper on one computer, you have many copies of the same thing. each new installation on same computer will need to download Mojang jar again and patch all. Because all jars are versioned, this creates no issue for multiple servers of different versions.
2. All of the directories (it makes 3: `cache`, `libraries`, `versions`) can be confusing to some players.

## Implementation

dev.dirs directories-jvm handle all the os specific possible issues with this. I add requireNonNullElse just in the case. especially for windows with some player running supposed debloater script this may return null.

## Alternative
If this is not accepted for some reason, maybe move all to `.paperclip` (or other name. this is my first idea) directory in server folder? This solves numero 2 above.