### PR TITLE
Mixin support for end users

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = io.papermc
-version = 3.0.4-SNAPSHOT
+version = 3.0.5-SNAPSHOT
 description = Launcher for the Paper Minecraft server

--- a/java17/build.gradle.kts
+++ b/java17/build.gradle.kts
@@ -17,15 +17,18 @@ tasks.withType<JavaCompile>().configureEach {
 
 repositories {
     mavenCentral()
+    maven("https://maven.fabricmc.net/")
 }
 
 dependencies {
+    implementation(project(":mixin-support"))
     implementation("io.sigpipe:jbsdiff:1.0")
 }
 
 tasks.shadowJar {
     val prefix = "paperclip.libs"
-    listOf("org.apache", "org.tukaani", "io.sigpipe").forEach { pack ->
+    // Spongepowered mixin relocation breaks service loaders, and is generally unneeded.
+    listOf("org.apache", "org.tukaani", "io.sigpipe", "com.google", "joptsimple", "org.objectweb", "org.jetbrains", "org.intellij", "org.yaml").forEach { pack ->
         relocate(pack, "$prefix.$pack")
     }
 

--- a/mixin-support/build.gradle.kts
+++ b/mixin-support/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `java-library`
+}
+
+repositories {
+    mavenCentral()
+    maven("https://maven.fabricmc.net/")
+}
+
+dependencies {
+    api("net.fabricmc:sponge-mixin:0.12.4+mixin.0.8.5")
+    api("org.yaml:snakeyaml:1.33")
+
+    api("org.jetbrains:annotations:23.0.0")
+    api("net.sf.jopt-simple:jopt-simple:5.0.4")
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/mixin/MixinLogger.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/mixin/MixinLogger.java
@@ -1,0 +1,49 @@
+package io.papermc.paperclip.mixin;
+
+import org.spongepowered.asm.logging.ILogger;
+import org.spongepowered.asm.logging.Level;
+import org.spongepowered.asm.logging.LoggerAdapterAbstract;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MixinLogger extends LoggerAdapterAbstract {
+    private static final Map<String, ILogger> LOGGER_MAP = new ConcurrentHashMap<>();
+
+    protected MixinLogger(String id) {
+        super(id);
+    }
+    
+    static ILogger get(String name) {
+        return LOGGER_MAP.computeIfAbsent(name, MixinLogger::new);
+    }
+
+    @Override
+    public String getType() {
+        return "Paperclip Mixin Logger";
+    }
+
+    @Override
+    public void catching(Level level, Throwable t) {
+        log(level, "Catching ".concat(t.toString()), t);
+    }
+
+    @Override
+    public void log(Level level, String message, Object... params) {
+        if (PaperclipLauncherBase.isDevelopment())
+            Util.info(level.name(), message, params);
+    }
+
+    @Override
+    public void log(Level level, String message, Throwable t) {
+        if (PaperclipLauncherBase.isDevelopment())
+            Util.info(level.name(), message, t);
+    }
+
+    @Override
+    public <T extends Throwable> T throwing(T t) {
+        log(Level.ERROR, "Throwing ".concat(t.toString()), t);
+
+        return t;
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/mixin/MixinStringPropertyKey.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/mixin/MixinStringPropertyKey.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.papermc.paperclip.mixin;
+
+import java.util.Objects;
+
+import org.spongepowered.asm.service.IPropertyKey;
+
+public record MixinStringPropertyKey(String key) implements IPropertyKey {
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof MixinStringPropertyKey)) {
+			return false;
+		} else {
+			return Objects.equals(this.key, ((MixinStringPropertyKey) obj).key);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return this.key;
+	}
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/mixin/PaperclipGlobalPropertyService.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/mixin/PaperclipGlobalPropertyService.java
@@ -1,0 +1,38 @@
+package io.papermc.paperclip.mixin;
+
+import org.spongepowered.asm.service.IGlobalPropertyService;
+import org.spongepowered.asm.service.IPropertyKey;
+
+public class PaperclipGlobalPropertyService implements IGlobalPropertyService {
+    @Override
+    public IPropertyKey resolveKey(String name) {
+        return new MixinStringPropertyKey(name);
+    }
+
+    private String keyString(IPropertyKey key) {
+        return ((MixinStringPropertyKey) key).key();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getProperty(IPropertyKey key) {
+        return (T) PaperclipLauncherBase.getProperties().get(keyString(key));
+    }
+
+    @Override
+    public void setProperty(IPropertyKey key, Object value) {
+        PaperclipLauncherBase.getProperties().put(keyString(key), value);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getProperty(IPropertyKey key, T defaultValue) {
+        return (T) PaperclipLauncherBase.getProperties().getOrDefault(keyString(key), defaultValue);
+    }
+
+    @Override
+    public String getPropertyString(IPropertyKey key, String defaultValue) {
+        Object o = PaperclipLauncherBase.getProperties().get(keyString(key));
+        return o != null ? o.toString() : defaultValue;
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/mixin/PaperclipLauncherBase.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/mixin/PaperclipLauncherBase.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.papermc.paperclip.mixin;
+
+import io.papermc.paperclip.mixin.classloader.MixinClassLoader;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mainly inspired by FabricLauncherBase.
+ */
+public final class PaperclipLauncherBase {
+    static MixinClassLoader classLoader;
+    static boolean mixinReady;
+    static final Map<String, Object> properties = new HashMap<>();
+
+    public static boolean isDevelopment() {
+        return false;
+    }
+
+    public static byte[] getClassByteArray(String name, boolean runTransformers) throws IOException {
+        if (runTransformers) {
+            return classLoader.getPreMixinClassBytes(name);
+        } else {
+            return classLoader.getRawClassBytes(name);
+        }
+    }
+
+    public static InputStream getResourceAsStream(String name) {
+        return classLoader.getResourceAsStream(name);
+    }
+
+    public static boolean isClassLoaded(String name) {
+        return classLoader.isClassLoaded(name);
+    }
+
+    public static Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    public static void addToClasspath(Path path, String... allowedPrefixes) {
+        classLoader.setAllowedPrefixes(path, allowedPrefixes);
+        classLoader.addCodeSource(path);
+    }
+
+    public static ClassLoader getTargetClassLoader() {
+        return PaperclipLauncherBase.classLoader;
+    }
+
+    public static void setClassLoader(MixinClassLoader classLoader) {
+        PaperclipLauncherBase.classLoader = classLoader;
+    }
+
+    public static void finishMixinBootstrapping() {
+        if (mixinReady) {
+            throw new RuntimeException("Must not call finishMixinBootstrapping() twice!");
+        }
+
+        try {
+            Method m = MixinEnvironment.class.getDeclaredMethod("gotoPhase", MixinEnvironment.Phase.class);
+            m.setAccessible(true);
+            m.invoke(null, MixinEnvironment.Phase.INIT);
+            m.invoke(null, MixinEnvironment.Phase.DEFAULT);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        mixinReady = true;
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/mixin/PaperclipMixinBootstrap.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/mixin/PaperclipMixinBootstrap.java
@@ -1,0 +1,39 @@
+package io.papermc.paperclip.mixin;
+
+import io.papermc.paperclip.plugin.PluginCandidateLoader;
+import io.papermc.paperclip.plugin.candidate.PluginCandidate;
+import io.papermc.paperclip.plugin.configuration.SimplePaperPluginMeta;
+import org.spongepowered.asm.launch.MixinBootstrap;
+import org.spongepowered.asm.mixin.Mixins;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PaperclipMixinBootstrap {
+    private PaperclipMixinBootstrap() {}
+
+    public static final PluginCandidateLoader PLUGIN_CANDIDATE_LOADER = new PluginCandidateLoader();
+
+    public static void init() {
+        System.setProperty("mixin.service", PaperclipMixinService.class.getName());
+        System.setProperty("mixin.bootstrapService", PaperclipMixinServiceBootstrap.class.getName());
+        MixinBootstrap.init();
+
+
+        final Map<String, PluginCandidate> uniqueCheck = new HashMap<>();
+        for (final PluginCandidate pluginCandidate : PLUGIN_CANDIDATE_LOADER.getPluginCandidates()) {
+            SimplePaperPluginMeta meta = pluginCandidate.getMeta();
+            if (meta == null)
+                return;
+            final String configFile = meta.mixinConfig().toString();
+            final PluginCandidate prev = uniqueCheck.putIfAbsent(configFile, pluginCandidate);
+            if (prev != null) throw new RuntimeException(String.format("Duplicate mixin config named %s used by plugins %s and %s", configFile, prev.getSource().getFileName(), pluginCandidate.getSource().getFileName()));
+
+            try {
+                Mixins.addConfiguration(configFile);
+            } catch (final Throwable e) {
+                throw new RuntimeException(String.format("Failed to handle mixin config for %s", pluginCandidate.getSource().getFileName()), e);
+            }
+        }
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/mixin/PaperclipMixinService.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/mixin/PaperclipMixinService.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.papermc.paperclip.mixin;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.launch.platform.container.ContainerHandleURI;
+import org.spongepowered.asm.launch.platform.container.IContainerHandle;
+import org.spongepowered.asm.logging.ILogger;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.transformer.IMixinTransformer;
+import org.spongepowered.asm.mixin.transformer.IMixinTransformerFactory;
+import org.spongepowered.asm.service.IClassBytecodeProvider;
+import org.spongepowered.asm.service.IClassProvider;
+import org.spongepowered.asm.service.IClassTracker;
+import org.spongepowered.asm.service.IMixinAuditTrail;
+import org.spongepowered.asm.service.IMixinInternal;
+import org.spongepowered.asm.service.IMixinService;
+import org.spongepowered.asm.service.ITransformer;
+import org.spongepowered.asm.service.ITransformerProvider;
+import org.spongepowered.asm.util.ReEntranceLock;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Mainly copied from net.fabricmc.loader.impl.launch.knot.MixinServiceKnot, edited for Paper needs.
+ */
+public final class PaperclipMixinService implements IMixinService, IClassProvider, IClassBytecodeProvider, ITransformerProvider, IClassTracker {
+    static IMixinTransformer transformer;
+
+    private final ReEntranceLock lock = new ReEntranceLock(1);;
+
+    public byte[] getClassBytes(String name, String transformedName) throws IOException {
+        return PaperclipLauncherBase.getClassByteArray(name, true);
+    }
+
+    public byte[] getClassBytes(String name, boolean runTransformers) throws ClassNotFoundException, IOException {
+        byte[] classBytes = PaperclipLauncherBase.getClassByteArray(name, runTransformers);
+
+        if (classBytes != null) {
+            return classBytes;
+        } else {
+            throw new ClassNotFoundException(name);
+        }
+    }
+
+    @Override
+    public ClassNode getClassNode(String name) throws ClassNotFoundException, IOException {
+        return getClassNode(name, true);
+    }
+
+    @Override
+    public ClassNode getClassNode(String name, boolean runTransformers) throws ClassNotFoundException, IOException {
+        ClassReader reader = new ClassReader(getClassBytes(name, runTransformers));
+        ClassNode node = new ClassNode();
+        reader.accept(node, 0);
+        return node;
+    }
+
+    @Override
+    public URL[] getClassPath() {
+        // Mixin 0.7.x only uses getClassPath() to find itself; we implement CodeSource correctly,
+        // so this is unnecessary.
+        return new URL[0];
+    }
+
+    @Override
+    public Class<?> findClass(String name) throws ClassNotFoundException {
+        return PaperclipLauncherBase.getTargetClassLoader().loadClass(name);
+    }
+
+    @Override
+    public Class<?> findClass(String name, boolean initialize) throws ClassNotFoundException {
+        return Class.forName(name, initialize, PaperclipLauncherBase.getTargetClassLoader());
+    }
+
+    @Override
+    public Class<?> findAgentClass(String name, boolean initialize) throws ClassNotFoundException {
+        return Class.forName(name, initialize, PaperclipLauncherBase.class.getClassLoader());
+    }
+
+    @Override
+    public String getName() {
+        return "Paperclip";
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public void prepare() { }
+
+    @Override
+    public MixinEnvironment.Phase getInitialPhase() {
+        return MixinEnvironment.Phase.PREINIT;
+    }
+
+    @Override
+    public void offer(IMixinInternal internal) {
+        if (internal instanceof IMixinTransformerFactory) {
+            transformer = ((IMixinTransformerFactory) internal).createTransformer();
+        }
+    }
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public void beginPhase() { }
+
+    @Override
+    public void checkEnv(Object bootSource) { }
+
+    @Override
+    public ReEntranceLock getReEntranceLock() {
+        return lock;
+    }
+
+    @Override
+    public IClassProvider getClassProvider() {
+        return this;
+    }
+
+    @Override
+    public IClassBytecodeProvider getBytecodeProvider() {
+        return this;
+    }
+
+    @Override
+    public ITransformerProvider getTransformerProvider() {
+        return this;
+    }
+
+    @Override
+    public IClassTracker getClassTracker() {
+        return this;
+    }
+
+    @Override
+    public IMixinAuditTrail getAuditTrail() {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getPlatformAgents() {
+        return Collections.singletonList("org.spongepowered.asm.launch.platform.MixinPlatformAgentDefault");
+    }
+
+    @Override
+    public IContainerHandle getPrimaryContainer() {
+        return new ContainerHandleURI(Util.LOADER_CODE_SOURCE.toUri());
+    }
+
+    @Override
+    public Collection<IContainerHandle> getMixinContainers() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String name) {
+        return PaperclipLauncherBase.getResourceAsStream(name);
+    }
+
+    @Override
+    public void registerInvalidClass(String className) { }
+
+    @Override
+    public boolean isClassLoaded(String className) {
+        return PaperclipLauncherBase.isClassLoaded(className);
+    }
+
+    @Override
+    public String getClassRestrictions(String className) {
+        return "";
+    }
+
+    @Override
+    public Collection<ITransformer> getTransformers() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<ITransformer> getDelegatedTransformers() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void addTransformerExclusion(String name) { }
+
+    @Override
+    public String getSideName() {
+        return "SERVER";
+    }
+
+    @Override
+    public MixinEnvironment.CompatibilityLevel getMinCompatibilityLevel() {
+        return MixinEnvironment.CompatibilityLevel.JAVA_8;
+    }
+
+    @Override
+    public MixinEnvironment.CompatibilityLevel getMaxCompatibilityLevel() {
+        return MixinEnvironment.CompatibilityLevel.JAVA_17;
+    }
+
+    @Override
+    public ILogger getLogger(String name) {
+        return MixinLogger.get(name);
+    }
+
+    public static IMixinTransformer getTransformer() {
+        return transformer;
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/mixin/PaperclipMixinServiceBootstrap.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/mixin/PaperclipMixinServiceBootstrap.java
@@ -1,0 +1,20 @@
+package io.papermc.paperclip.mixin;
+
+import org.spongepowered.asm.service.IMixinServiceBootstrap;
+
+public class PaperclipMixinServiceBootstrap implements IMixinServiceBootstrap {
+    @Override
+    public String getName() {
+        return "Paperclip";
+    }
+
+    @Override
+    public String getServiceClassName() {
+        return "io.papermc.paperclip.mixin.PaperclipMixinService";
+    }
+
+    @Override
+    public void bootstrap() {
+
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/mixin/Util.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/mixin/Util.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.papermc.paperclip.mixin;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.CodeSource;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.jar.Manifest;
+import java.util.zip.ZipError;
+
+/**
+ *  Contains fabric licensed code, a combination of many small utility classes.
+ */
+public final class Util {
+    public static final Path LOADER_CODE_SOURCE = getCodeSource(Util.class);
+
+    public static String getClassFileName(String className) {
+        return className.replace('.', '/').concat(".class");
+    }
+
+    public static Path normalizePath(Path path) {
+        if (Files.exists(path)) {
+            return normalizeExistingPath(path);
+        } else {
+            return path.toAbsolutePath().normalize();
+        }
+    }
+
+    public static Path normalizeExistingPath(Path path) {
+        try {
+            return path.toRealPath();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static Path getCodeSource(Class<?> cls) {
+        CodeSource cs = cls.getProtectionDomain().getCodeSource();
+        if (cs == null) return null;
+
+        return asPath(cs.getLocation());
+    }
+
+    public static URL asUrl(Path path) throws MalformedURLException {
+        return path.toUri().toURL();
+    }
+
+    public static Path asPath(URL url) {
+        try {
+            return Paths.get(url.toURI());
+        } catch (URISyntaxException e) {
+            throw Util.wrap(e);
+        }
+    }
+
+    public static final class WrappedException extends RuntimeException {
+        public WrappedException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static RuntimeException wrap(Throwable exc) {
+        if (exc instanceof RuntimeException) return (RuntimeException) exc;
+
+        exc = unwrap(exc);
+        if (exc instanceof RuntimeException) return (RuntimeException) exc;
+
+        return new WrappedException(exc);
+    }
+
+    private static Throwable unwrap(Throwable exc) {
+        if (exc instanceof WrappedException
+                || exc instanceof UncheckedIOException
+                || exc instanceof ExecutionException
+                || exc instanceof CompletionException) {
+            Throwable ret = exc.getCause();
+            if (ret != null) return unwrap(ret);
+        }
+
+        return exc;
+    }
+
+    public static class UrlConversionException extends Exception {
+        public UrlConversionException() {
+            super();
+        }
+
+        public UrlConversionException(String s) {
+            super(s);
+        }
+
+        public UrlConversionException(Throwable t) {
+            super(t);
+        }
+
+        public UrlConversionException(String s, Throwable t) {
+            super(s, t);
+        }
+    }
+
+    public static Path getCodeSource(URL url, String localPath) throws UrlConversionException {
+        try {
+            URLConnection connection = url.openConnection();
+
+            if (connection instanceof JarURLConnection) {
+                return asPath(((JarURLConnection) connection).getJarFileURL());
+            } else {
+                String path = url.getPath();
+
+                if (path.endsWith(localPath)) {
+                    return asPath(new URL(url.getProtocol(), url.getHost(), url.getPort(), path.substring(0, path.length() - localPath.length())));
+                } else {
+                    throw new UrlConversionException("Could not figure out code source for file '" + localPath + "' in URL '" + url + "'!");
+                }
+            }
+        } catch (Exception e) {
+            throw new UrlConversionException(e);
+        }
+    }
+
+    public static Manifest readManifest(URL codeSourceUrl) throws IOException, URISyntaxException {
+        Path path = Util.asPath(codeSourceUrl);
+
+        if (Files.isDirectory(path)) {
+            return readManifest(path);
+        } else {
+            URLConnection connection = new URL("jar:" + codeSourceUrl.toString() + "!/").openConnection();
+
+            if (connection instanceof JarURLConnection) {
+                return ((JarURLConnection) connection).getManifest();
+            }
+
+            try (Util.FileSystemDelegate jarFs = Util.getJarFileSystem(path, false)) {
+                return readManifest(jarFs.get().getRootDirectories().iterator().next());
+            }
+        }
+    }
+
+    public static Manifest readManifest(Path basePath) throws IOException {
+        Path path = basePath.resolve("META-INF").resolve("MANIFEST.MF");
+        if (!Files.exists(path)) return null;
+
+        try (InputStream stream = Files.newInputStream(path)) {
+            return new Manifest(stream);
+        }
+    }
+
+    public static class FileSystemDelegate implements AutoCloseable {
+        private final FileSystem fileSystem;
+        private final boolean owner;
+
+        public FileSystemDelegate(FileSystem fileSystem, boolean owner) {
+            this.fileSystem = fileSystem;
+            this.owner = owner;
+        }
+
+        public FileSystem get() {
+            return fileSystem;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (owner) {
+                fileSystem.close();
+            }
+        }
+    }
+
+    private static final Map<String, String> jfsArgsCreate = Collections.singletonMap("create", "true");
+    private static final Map<String, String> jfsArgsEmpty = Collections.emptyMap();
+
+
+    public static FileSystemDelegate getJarFileSystem(Path path, boolean create) throws IOException {
+        return getJarFileSystem(path.toUri(), create);
+    }
+
+    public static FileSystemDelegate getJarFileSystem(URI uri, boolean create) throws IOException {
+        URI jarUri;
+
+        try {
+            jarUri = new URI("jar:" + uri.getScheme(), uri.getHost(), uri.getPath(), uri.getFragment());
+        } catch (URISyntaxException e) {
+            throw new IOException(e);
+        }
+
+        boolean opened = false;
+        FileSystem ret = null;
+
+        try {
+            ret = FileSystems.getFileSystem(jarUri);
+        } catch (FileSystemNotFoundException ignore) {
+            try {
+                ret = FileSystems.newFileSystem(jarUri, create ? jfsArgsCreate : jfsArgsEmpty);
+                opened = true;
+            } catch (FileSystemAlreadyExistsException ignore2) {
+                ret = FileSystems.getFileSystem(jarUri);
+            } catch (IOException | ZipError e) {
+                throw new IOException("Error accessing " + uri + ": " + e, e);
+            }
+        }
+
+        return new FileSystemDelegate(ret, opened);
+    }
+
+    public static void error(String marker, String message) {
+        print("ERROR", marker, message);
+    }
+
+    public static void error(String marker, String message, Throwable t) {
+        print("ERROR", marker, message, t);
+    }
+
+    public static void info(String marker, String message, Throwable t) {
+        print("INFO", marker, message, t);
+    }
+
+    public static void info(String marker, String message, Object... objects) {
+        print("INFO", marker, message, objects);
+    }
+
+    public static void warn(String marker, String message, Object... objects) {
+        print("WARN", marker, message, objects);
+    }
+
+    private static void print(String prefix, String marker, String message, Object... objects) {
+        System.out.println("["+prefix+"] " + "["+marker+"] " + String.format(message, objects));
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/mixin/classloader/ClassLoaderAccess.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/mixin/classloader/ClassLoaderAccess.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.papermc.paperclip.mixin.classloader;
+
+import java.net.URL;
+import java.security.CodeSource;
+
+/**
+ * copied from net.fabricmc.loader.impl.launch.knot.KnotClassDelegate
+ */
+public interface ClassLoaderAccess {
+    void addUrlFwd(URL url);
+    URL findResourceFwd(String name);
+
+    Package getPackageFwd(String name);
+    Package definePackageFwd(String name, String specTitle, String specVersion, String specVendor, String implTitle, String implVersion, String implVendor, URL sealBase) throws IllegalArgumentException;
+
+    Object getClassLoadingLockFwd(String name);
+    Class<?> findLoadedClassFwd(String name);
+    Class<?> defineClassFwd(String name, byte[] b, int off, int len, CodeSource cs);
+    void resolveClassFwd(Class<?> cls);
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/mixin/classloader/MixinClassLoader.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/mixin/classloader/MixinClassLoader.java
@@ -1,0 +1,640 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.papermc.paperclip.mixin.classloader;
+
+import io.papermc.paperclip.mixin.PaperclipLauncherBase;
+import io.papermc.paperclip.mixin.PaperclipMixinService;
+import io.papermc.paperclip.mixin.Util;
+import org.spongepowered.asm.mixin.transformer.IMixinTransformer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.net.URLConnection;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.CodeSource;
+import java.security.SecureClassLoader;
+import java.security.cert.Certificate;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.Manifest;
+
+/**
+ * Contains a lot of Fabric Loader code,
+ * a combination of net.fabricmc.loader.impl.launch.knot.KnotClassDelegate and
+ * net.fabricmc.loader.impl.launch.knot.KnotClassLoader, edited for Paper needs.
+ */
+public class MixinClassLoader extends SecureClassLoader implements ClassLoaderAccess {
+
+    private static final boolean LOG_CLASS_LOAD = System.getProperty("paperclip.debug_log_class_load") != null;
+    private static final boolean LOG_CLASS_LOAD_ERRORS = LOG_CLASS_LOAD || System.getProperty("paperclip.debug_load_class_load_errors") != null;
+    private static final boolean LOG_TRANSFORM_ERRORS = System.getProperty("paperclip.debug_load_transform_errors") != null;
+    private static final boolean DISABLE_ISOLATION = System.getProperty("paperclip.disable_classpath_isolation") != null;
+
+    private static final ClassLoader PLATFORM_CLASS_LOADER = platformClassLoader();
+
+    private final Map<Path, Metadata> metadataCache = new ConcurrentHashMap<>();
+    private final DynamicURLClassLoader urlLoader;
+    private final ClassLoader parentClassLoader;
+    private IMixinTransformer mixinTransformer;
+    private boolean transformInitialized = false;
+    private volatile Set<Path> codeSources = Collections.emptySet();
+    private volatile Set<Path> validParentCodeSources = Collections.emptySet();
+    private final Map<Path, String[]> allowedPrefixes = new ConcurrentHashMap<>();
+    private final Set<String> parentSourcedClasses = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    public MixinClassLoader() {
+        super(new DynamicURLClassLoader(new URL[0]));
+        this.parentClassLoader = getClass().getClassLoader();
+        this.urlLoader = (DynamicURLClassLoader) getParent();
+    }
+
+    public void initializeTransformers() {
+        if (transformInitialized) throw new IllegalStateException("Cannot initialize KnotClassDelegate twice!");
+
+        mixinTransformer = PaperclipMixinService.getTransformer();
+
+        if (mixinTransformer == null) {
+            try { // reflective instantiation for older mixin versions
+                @SuppressWarnings("unchecked")
+                Constructor<IMixinTransformer> ctor = (Constructor<IMixinTransformer>) Class.forName("org.spongepowered.asm.mixin.transformer.MixinTransformer").getConstructor();
+                ctor.setAccessible(true);
+                mixinTransformer = ctor.newInstance();
+            } catch (ReflectiveOperationException e) {
+                Util.error("MixinClassloader", "Can't create Mixin transformer through reflection (only applicable for 0.8-0.8.2): %s", e);
+
+                // both lookups failed (not received through IMixinService.offer and not found through reflection)
+                throw new IllegalStateException("mixin transformer unavailable?");
+            }
+        }
+
+        transformInitialized = true;
+    }
+
+    private IMixinTransformer getMixinTransformer() {
+        assert mixinTransformer != null;
+        return mixinTransformer;
+    }
+
+    @Override
+    public URL getResource(String name) {
+        Objects.requireNonNull(name);
+
+        URL url = urlLoader.getResource(name);
+
+        if (url == null) {
+            url = parentClassLoader.getResource(name);
+        }
+
+        return url;
+    }
+
+    @Override
+    public URL findResource(String name) {
+        Objects.requireNonNull(name);
+
+        return urlLoader.findResource(name);
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String name) {
+        Objects.requireNonNull(name);
+
+        InputStream inputStream = urlLoader.getResourceAsStream(name);
+
+        if (inputStream == null) {
+            inputStream = parentClassLoader.getResourceAsStream(name);
+        }
+
+        return inputStream;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        Objects.requireNonNull(name);
+
+        final Enumeration<URL> resources = urlLoader.getResources(name);
+
+        if (!resources.hasMoreElements()) {
+            return parentClassLoader.getResources(name);
+        }
+
+        return resources;
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLockFwd(name)) {
+            Class<?> c = findLoadedClassFwd(name);
+
+            if (c == null) {
+                if (name.startsWith("java.")) { // fast path for java.** (can only be loaded by the platform CL anyway)
+                    c = PLATFORM_CLASS_LOADER.loadClass(name);
+                } else {
+                    c = tryLoadClass(name, false); // try local load
+
+                    if (c == null) { // not available locally, try system class loader
+                        String fileName = Util.getClassFileName(name);
+                        URL url = parentClassLoader.getResource(fileName);
+
+                        if (url == null) { // no .class file
+                            try {
+                                c = PLATFORM_CLASS_LOADER.loadClass(name);
+                                if (LOG_CLASS_LOAD) Util.info("MixinClassLoader", "loaded resources-less class %s from platform class loader");
+                            } catch (ClassNotFoundException e) {
+                                if (LOG_CLASS_LOAD_ERRORS) Util.warn("MixinClassLoader", "can't find class %s", name);
+                                throw e;
+                            }
+                        } else if (!isValidParentUrl(url, fileName)) { // available, but restricted
+                            // The class would technically be available, but the game provider restricted it from being
+                            // loaded by setting validParentUrls and not including "url". Typical causes are:
+                            // - accessing classes too early (game libs shouldn't be used until Loader is ready)
+                            // - using jars that are only transient (deobfuscation input or pass-through installers)
+                            String msg = String.format("can't load class %s at %s as it hasn't been exposed to the game",
+                                    name, getCodeSource(url, fileName));
+                            if (LOG_CLASS_LOAD_ERRORS) Util.warn("MixinClassLoader", msg);
+                            throw new ClassNotFoundException(msg);
+                        } else { // load from system cl
+                            if (LOG_CLASS_LOAD) Util.info("MixinClassLoader", "loading class %s using the parent class loader", name);
+                            c = parentClassLoader.loadClass(name);
+                        }
+                    } else if (LOG_CLASS_LOAD) {
+                        Util.info("MixinClassLoader", "loaded class %s", name);
+                    }
+                }
+            }
+
+            if (resolve) {
+                resolveClassFwd(c);
+            }
+
+            return c;
+        }
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        return tryLoadClass(name, false);
+    }
+
+    @Override
+    public void addUrlFwd(URL url) {
+        urlLoader.addURL(url);
+    }
+
+    @Override
+    public URL findResourceFwd(String name) {
+        return urlLoader.findResource(name);
+    }
+
+    @Override
+    public Package getPackageFwd(String name) {
+        return super.getPackage(name);
+    }
+
+    @Override
+    public Package definePackageFwd(String name, String specTitle, String specVersion, String specVendor,
+                                    String implTitle, String implVersion, String implVendor, URL sealBase) throws IllegalArgumentException {
+        return super.definePackage(name, specTitle, specVersion, specVendor, implTitle, implVersion, implVendor, sealBase);
+    }
+
+    @Override
+    public Object getClassLoadingLockFwd(String name) {
+        return super.getClassLoadingLock(name);
+    }
+
+    @Override
+    public Class<?> findLoadedClassFwd(String name) {
+        return super.findLoadedClass(name);
+    }
+
+    @Override
+    public Class<?> defineClassFwd(String name, byte[] b, int off, int len, CodeSource cs) {
+        return super.defineClass(name, b, off, len, cs);
+    }
+
+    @Override
+    public void resolveClassFwd(Class<?> cls) {
+        super.resolveClass(cls);
+    }
+
+    public void addCodeSource(Path path) {
+        path = Util.normalizeExistingPath(path);
+
+        synchronized (this) {
+            Set<Path> codeSources = this.codeSources;
+            if (codeSources.contains(path)) return;
+
+            Set<Path> newCodeSources = new HashSet<>(codeSources.size() + 1, 1);
+            newCodeSources.addAll(codeSources);
+            newCodeSources.add(path);
+
+            this.codeSources = newCodeSources;
+        }
+
+        try {
+            addUrlFwd(Util.asUrl(path));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (LOG_CLASS_LOAD_ERRORS) Util.info("MixinClassLoader", "added code source %s", path);
+    }
+
+    public void setAllowedPrefixes(Path codeSource, String... prefixes) {
+        codeSource = Util.normalizeExistingPath(codeSource);
+
+        if (prefixes.length == 0) {
+            allowedPrefixes.remove(codeSource);
+        } else {
+            allowedPrefixes.put(codeSource, prefixes);
+        }
+    }
+
+    public void setValidParentClassPath(Collection<Path> paths) {
+        Set<Path> validPaths = new HashSet<>(paths.size(), 1);
+
+        for (Path path : paths) {
+            validPaths.add(Util.normalizeExistingPath(path));
+        }
+
+        this.validParentCodeSources = validPaths;
+    }
+
+    public Manifest getManifest(Path codeSource) {
+        return getMetadata(Util.normalizeExistingPath(codeSource)).manifest;
+    }
+
+    public boolean isClassLoaded(String name) {
+        synchronized (getClassLoadingLockFwd(name)) {
+            return findLoadedClassFwd(name) != null;
+        }
+    }
+
+    public Class<?> loadIntoTarget(String name) throws ClassNotFoundException {
+        synchronized (getClassLoadingLockFwd(name)) {
+            Class<?> c = findLoadedClassFwd(name);
+
+            if (c == null) {
+                c = tryLoadClass(name, true);
+
+                if (c == null) {
+                    throw new ClassNotFoundException("can't find class "+name);
+                } else if (LOG_CLASS_LOAD) {
+                    Util.info("MixinClassLoader", "loaded class %s into target", name);
+                }
+            }
+
+            resolveClassFwd(c);
+
+            return c;
+        }
+    }
+
+    /**
+     * Check if an url is loadable by the parent class loader.
+     *
+     * <p>This handles explicit parent url whitelisting by {@link #validParentCodeSources} or shadowing by {@link #codeSources}
+     */
+    private boolean isValidParentUrl(URL url, String fileName) {
+        if (url == null) return false;
+        if (DISABLE_ISOLATION) return true;
+        if (!hasRegularCodeSource(url)) return true;
+
+        Path codeSource = getCodeSource(url, fileName);
+        Set<Path> validParentCodeSources = this.validParentCodeSources;
+
+        if (validParentCodeSources != null) { // explicit whitelist (in addition to platform cl classes)
+            return validParentCodeSources.contains(codeSource) || PLATFORM_CLASS_LOADER.getResource(fileName) != null;
+        } else { // reject urls shadowed by this cl
+            return !codeSources.contains(codeSource);
+        }
+    }
+
+    Class<?> tryLoadClass(String name, boolean allowFromParent) throws ClassNotFoundException {
+        if (name.startsWith("java.")) {
+            return null;
+        }
+
+        if (!allowedPrefixes.isEmpty() && !DISABLE_ISOLATION) { // check prefix restrictions (allows exposing libraries partially during startup)
+            String fileName = Util.getClassFileName(name);
+            URL url = getResource(fileName);
+
+            if (url != null && hasRegularCodeSource(url)) {
+                Path codeSource = getCodeSource(url, fileName);
+                String[] prefixes = allowedPrefixes.get(codeSource);
+
+                if (prefixes != null) {
+                    assert prefixes.length > 0;
+                    boolean found = false;
+
+                    for (String prefix : prefixes) {
+                        if (name.startsWith(prefix)) {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if (!found) {
+                        String msg = "class "+name+" is currently restricted from being loaded";
+                        if (LOG_CLASS_LOAD_ERRORS) Util.warn("MixinClassLoader", msg);
+                        throw new ClassNotFoundException(msg);
+                    }
+                }
+            }
+        }
+
+        if (!allowFromParent && !parentSourcedClasses.isEmpty()) { // propagate loadIntoTarget behavior to its nested classes
+            int pos = name.length();
+
+            while ((pos = name.lastIndexOf('$', pos - 1)) > 0) {
+                if (parentSourcedClasses.contains(name.substring(0, pos))) {
+                    allowFromParent = true;
+                    break;
+                }
+            }
+        }
+
+        byte[] input = getPostMixinClassByteArray(name, allowFromParent);
+        if (input == null) return null;
+
+        // The class we're currently loading could have been loaded already during Mixin initialization triggered by `getPostMixinClassByteArray`.
+        // If this is the case, we want to return the instance that was already defined to avoid attempting a duplicate definition.
+        Class<?> existingClass = findLoadedClassFwd(name);
+
+        if (existingClass != null) {
+            return existingClass;
+        }
+
+        if (allowFromParent) {
+            parentSourcedClasses.add(name);
+        }
+
+        Metadata metadata = getMetadata(name);
+
+        int pkgDelimiterPos = name.lastIndexOf('.');
+
+        if (pkgDelimiterPos > 0) {
+            // TODO: package definition stub
+            String pkgString = name.substring(0, pkgDelimiterPos);
+
+            if (getPackageFwd(pkgString) == null) {
+                try {
+                    definePackageFwd(pkgString, null, null, null, null, null, null, null);
+                } catch (IllegalArgumentException e) { // presumably concurrent package definition
+                    if (getPackageFwd(pkgString) == null) throw e; // still not defined?
+                }
+            }
+        }
+
+        return defineClassFwd(name, input, 0, input.length, metadata.codeSource);
+    }
+
+    private Metadata getMetadata(String name) {
+        String fileName = Util.getClassFileName(name);
+        URL url = getResource(fileName);
+        if (url == null || !hasRegularCodeSource(url)) return Metadata.EMPTY;
+
+        return getMetadata(getCodeSource(url, fileName));
+    }
+
+    private Metadata getMetadata(Path codeSource) {
+        return metadataCache.computeIfAbsent(codeSource, (Path path) -> {
+            Manifest manifest = null;
+            CodeSource cs = null;
+            Certificate[] certificates = null;
+
+            try {
+                if (Files.isDirectory(path)) {
+                    manifest = Util.readManifest(path);
+                } else {
+                    URLConnection connection = new URL("jar:" + path.toUri().toString() + "!/").openConnection();
+
+                    if (connection instanceof JarURLConnection) {
+                        manifest = ((JarURLConnection) connection).getManifest();
+                        certificates = ((JarURLConnection) connection).getCertificates();
+                    }
+
+                    if (manifest == null) {
+                        try (Util.FileSystemDelegate jarFs = Util.getJarFileSystem(path, false)) {
+                            manifest = Util.readManifest(jarFs.get().getRootDirectories().iterator().next());
+                        }
+                    }
+
+                    // TODO
+					/* JarEntry codeEntry = codeSourceJar.getJarEntry(filename);
+
+					if (codeEntry != null) {
+						cs = new CodeSource(codeSourceURL, codeEntry.getCodeSigners());
+					} */
+                }
+            } catch (IOException | FileSystemNotFoundException e) {
+                if (PaperclipLauncherBase.isDevelopment()) {
+                    Util.warn("MixinClassLoader", "Failed to load manifest", e);
+                }
+            }
+
+            if (cs == null) {
+                try {
+                    cs = new CodeSource(Util.asUrl(path), certificates);
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            return new Metadata(manifest, cs);
+        });
+    }
+
+    private byte[] getPostMixinClassByteArray(String name, boolean allowFromParent) {
+        byte[] transformedClassArray = getPreMixinClassByteArray(name, allowFromParent);
+
+        if (!transformInitialized || !canTransformClass(name)) {
+            return transformedClassArray;
+        }
+
+        try {
+            return getMixinTransformer().transformClassBytes(name, name, transformedClassArray);
+        } catch (Throwable t) {
+            String msg = String.format("Mixin transformation of %s failed", name);
+            if (LOG_TRANSFORM_ERRORS) Util.warn("MixinClassLoader", msg, t);
+
+            throw new RuntimeException(msg, t);
+        }
+    }
+
+    public byte[] getPreMixinClassBytes(String name) {
+        return getPreMixinClassByteArray(name, true);
+    }
+
+    /**
+     * Runs all the class transformers except mixin. (No other transformers on Paper!)
+     */
+    private byte[] getPreMixinClassByteArray(String name, boolean allowFromParent) {
+        // some of the transformers rely on dot notation
+        name = name.replace('/', '.');
+
+        if (!transformInitialized || !canTransformClass(name)) {
+            try {
+                return getRawClassByteArray(name, allowFromParent);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to load class file for '" + name + "'!", e);
+            }
+        }
+
+        try {
+            return getRawClassByteArray(name, allowFromParent);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load class file for '" + name + "'!", e);
+        }
+    }
+
+    private static boolean canTransformClass(String name) {
+        name = name.replace('/', '.');
+        // Blocking Fabric Loader classes is no longer necessary here as they don't exist on the modding class loader
+        return /* !"net.fabricmc.api.EnvType".equals(name) && !name.startsWith("net.fabricmc.loader.") && */ !name.startsWith("org.apache.logging.log4j");
+    }
+
+    public byte[] getRawClassBytes(String name) throws IOException {
+        return getRawClassByteArray(name, true);
+    }
+
+    private byte[] getRawClassByteArray(String name, boolean allowFromParent) throws IOException {
+        name = Util.getClassFileName(name);
+        URL url = findResourceFwd(name);
+
+        if (url == null) {
+            if (!allowFromParent) return null;
+
+            url = parentClassLoader.getResource(name);
+
+            if (!isValidParentUrl(url, name)) {
+                if (LOG_CLASS_LOAD) Util.info("refusing to load class %s at %s from parent class loader", name, getCodeSource(url, name));
+
+                return null;
+            }
+        }
+
+        try (InputStream inputStream = url.openStream()) {
+            int a = inputStream.available();
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream(a < 32 ? 32768 : a);
+            byte[] buffer = new byte[8192];
+            int len;
+
+            while ((len = inputStream.read(buffer)) > 0) {
+                outputStream.write(buffer, 0, len);
+            }
+
+            return outputStream.toByteArray();
+        }
+    }
+
+    private static boolean hasRegularCodeSource(URL url) {
+        return url.getProtocol().equals("file") || url.getProtocol().equals("jar");
+    }
+
+    private static Path getCodeSource(URL url, String fileName) {
+        try {
+            return Util.normalizeExistingPath(Util.getCodeSource(url, fileName));
+        } catch (Util.UrlConversionException e) {
+            throw Util.wrap(e);
+        }
+    }
+
+    private static ClassLoader platformClassLoader() {
+        try {
+            return (ClassLoader) ClassLoader.class.getMethod("getPlatformClassLoader").invoke(null); // Java 9+ only
+        } catch (NoSuchMethodException e) {
+            return new ClassLoader(null) { }; // fall back to boot cl
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static final class Metadata {
+        static final Metadata EMPTY = new Metadata(null, null);
+
+        final Manifest manifest;
+        final CodeSource codeSource;
+
+        Metadata(Manifest manifest, CodeSource codeSource) {
+            this.manifest = manifest;
+            this.codeSource = codeSource;
+        }
+    }
+
+    private static final class DynamicURLClassLoader extends URLClassLoader {
+        private DynamicURLClassLoader(URL[] urls) {
+            super(urls, new DummyClassLoader());
+        }
+
+        @Override
+        public void addURL(URL url) {
+            super.addURL(url);
+        }
+
+        static {
+            registerAsParallelCapable();
+        }
+    }
+
+    static class DummyClassLoader extends ClassLoader {
+        private static final Enumeration<URL> NULL_ENUMERATION = new Enumeration<>() {
+            @Override
+            public boolean hasMoreElements() {
+                return false;
+            }
+
+            @Override
+            public URL nextElement() {
+                return null;
+            }
+        };
+
+        static {
+            registerAsParallelCapable();
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            throw new ClassNotFoundException(name);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return null;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String var1) throws IOException {
+            return NULL_ENUMERATION;
+        }
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/plugin/PluginCandidateLoader.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/plugin/PluginCandidateLoader.java
@@ -1,0 +1,30 @@
+package io.papermc.paperclip.plugin;
+
+import io.papermc.paperclip.plugin.candidate.PluginCandidate;
+import io.papermc.paperclip.plugin.candidate.source.DirectoryProviderSource;
+import io.papermc.paperclip.plugin.candidate.source.PluginFlagProviderSource;
+import joptsimple.OptionSet;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public final class PluginCandidateLoader {
+    final Collection<PluginCandidate> candidates = new ArrayList<>();
+
+    public Collection<Path> load(OptionSet optionSet) {
+        final Path pluginDirectory = ((File) optionSet.valueOf("plugins")).toPath();
+        try {
+            this.candidates.addAll(DirectoryProviderSource.INSTANCE.getCandidates(pluginDirectory));
+        } catch (Exception e) {}
+        @SuppressWarnings("unchecked")
+        java.util.List<File> files = (java.util.List<File>) optionSet.valuesOf("add-plugin");
+        this.candidates.addAll(PluginFlagProviderSource.INSTANCE.getCandidates(files));
+        return candidates.stream().map(PluginCandidate::getSource).toList();
+    }
+
+    public Collection<PluginCandidate> getPluginCandidates() {
+        return this.candidates;
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/PaperPluginCandidate.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/PaperPluginCandidate.java
@@ -1,0 +1,34 @@
+package io.papermc.paperclip.plugin.candidate;
+
+import io.papermc.paperclip.plugin.configuration.SimplePaperPluginMeta;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.util.jar.JarFile;
+
+public class PaperPluginCandidate implements PluginCandidate {
+    final Path source;
+    final JarFile jarFile;
+    final SimplePaperPluginMeta meta;
+
+    public PaperPluginCandidate(Path source, JarFile jarFile, SimplePaperPluginMeta meta) {
+        this.source = source;
+        this.jarFile = jarFile;
+        this.meta = meta;
+    }
+
+    @Override
+    public @NotNull Path getSource() {
+        return this.source;
+    }
+
+    @Override
+    public JarFile file() {
+        return this.jarFile;
+    }
+
+    @Override
+    public SimplePaperPluginMeta getMeta() {
+        return this.meta;
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/PluginCandidate.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/PluginCandidate.java
@@ -1,0 +1,24 @@
+package io.papermc.paperclip.plugin.candidate;
+
+import io.papermc.paperclip.plugin.configuration.SimplePaperPluginMeta;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.util.jar.JarFile;
+
+public interface PluginCandidate {
+    @NotNull
+    Path getSource();
+
+    default Path getFileName() {
+        return this.getSource().getFileName();
+    }
+
+    default Path getParentSource() {
+        return this.getSource().getParent();
+    }
+
+    JarFile file();
+
+    SimplePaperPluginMeta getMeta();
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/source/DirectoryProviderSource.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/source/DirectoryProviderSource.java
@@ -1,0 +1,37 @@
+package io.papermc.paperclip.plugin.candidate.source;
+
+import io.papermc.paperclip.mixin.Util;
+import io.papermc.paperclip.plugin.candidate.PluginCandidate;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Loads all plugin providers in the given directory.
+ */
+public class DirectoryProviderSource implements ProviderSource<Path> {
+
+    public static final DirectoryProviderSource INSTANCE = new DirectoryProviderSource();
+    private final FileProviderSource fileProviderSource = new FileProviderSource("File '%s'"::formatted);
+
+    @Override
+    public Collection<PluginCandidate> getCandidates(Path context) throws Exception {
+        // Sym link happy, create file if missing.
+        if (!Files.isDirectory(context)) {
+            Files.createDirectories(context);
+        }
+        final Collection<PluginCandidate> pluginCandidates = new ArrayList<>();
+        Files.walk(context, 1).filter(Files::isRegularFile).forEach((path) -> {
+            try {
+                pluginCandidates.add(fileProviderSource.getCandidate(path));
+            } catch (IllegalArgumentException ignored) {
+                // Ignore initial argument exceptions
+            } catch (Exception e) {
+                Util.error("DirectoryProviderSource", "Error loading plugin: " + e.getMessage());
+            }
+        });
+        return pluginCandidates;
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/source/FileProviderSource.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/source/FileProviderSource.java
@@ -1,0 +1,46 @@
+package io.papermc.paperclip.plugin.candidate.source;
+
+import io.papermc.paperclip.plugin.candidate.PaperPluginCandidate;
+import io.papermc.paperclip.plugin.candidate.PluginCandidate;
+import io.papermc.paperclip.plugin.configuration.SimplePaperPluginMeta;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Function;
+import java.util.jar.JarFile;
+
+/**
+ * Loads a plugin provider at the given plugin jar file path.
+ */
+public class FileProviderSource {
+
+    private final Function<Path, String> contextChecker;
+
+    public FileProviderSource(Function<Path, String> contextChecker) {
+        this.contextChecker = contextChecker;
+    }
+
+    public PluginCandidate getCandidate(Path context) {
+        String source = this.contextChecker.apply(context);
+
+        if (Files.notExists(context)) {
+            throw new IllegalArgumentException(source + " does not exist, cannot load a plugin from it!");
+        }
+
+        if (!Files.isRegularFile(context)) {
+            throw new IllegalArgumentException(source + " is not a file, cannot load a plugin from it!");
+        }
+
+        if (!context.getFileName().toString().endsWith(".jar")) {
+            throw new IllegalArgumentException(source + " is not a jar file, cannot load a plugin from it!");
+        }
+
+        try {
+            JarFile file = new JarFile(context.toFile(), true, JarFile.OPEN_READ, JarFile.runtimeVersion());
+            return new PaperPluginCandidate(context.toAbsolutePath(), file, SimplePaperPluginMeta.from(file));
+        } catch (Exception exception) {
+            throw new RuntimeException(source + " failed to load!", exception);
+        }
+    }
+
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/source/PluginFlagProviderSource.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/source/PluginFlagProviderSource.java
@@ -1,0 +1,31 @@
+package io.papermc.paperclip.plugin.candidate.source;
+
+import io.papermc.paperclip.mixin.Util;
+import io.papermc.paperclip.plugin.candidate.PluginCandidate;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Registers providers at the provided files in the add-plugin argument.
+ */
+public class PluginFlagProviderSource implements ProviderSource<List<File>> {
+
+    public static final PluginFlagProviderSource INSTANCE = new PluginFlagProviderSource();
+    private final FileProviderSource providerSource = new FileProviderSource("File '%s' specified through 'add-plugin' argument"::formatted);
+
+    @Override
+    public Collection<PluginCandidate> getCandidates(List<File> context) {
+        Collection<PluginCandidate> pluginCandidates = new ArrayList<>();
+        for (File file : context) {
+            try {
+                pluginCandidates.add(this.providerSource.getCandidate(file.toPath()));
+            } catch (Exception e) {
+                Util.error("PluginFlagProviderSource", "Error loading plugin: " + e.getMessage());
+            }
+        }
+        return pluginCandidates;
+    }
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/source/ProviderSource.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/plugin/candidate/source/ProviderSource.java
@@ -1,0 +1,16 @@
+package io.papermc.paperclip.plugin.candidate.source;
+
+import io.papermc.paperclip.plugin.candidate.PluginCandidate;
+
+import java.util.Collection;
+
+/**
+ * A provider source is responsible for giving PluginTypes an EntrypointHandler for
+ * registering providers at.
+ *
+ * @param <C> context
+ */
+public interface ProviderSource<C> {
+
+    Collection<PluginCandidate> getCandidates(C context) throws Throwable;
+}

--- a/mixin-support/src/main/java/io/papermc/paperclip/plugin/configuration/SimplePaperPluginMeta.java
+++ b/mixin-support/src/main/java/io/papermc/paperclip/plugin/configuration/SimplePaperPluginMeta.java
@@ -1,0 +1,26 @@
+package io.papermc.paperclip.plugin.configuration;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+public record SimplePaperPluginMeta(Path mixinConfig) {
+
+    public static SimplePaperPluginMeta from(JarFile jarFile) {
+        final Yaml yaml = new Yaml();
+        JarEntry jarEntry = jarFile.getJarEntry("paper-plugin.yml");
+        if (jarEntry == null)
+            return null;
+        try {
+            Map<String, Object> loaded = yaml.load(jarFile.getInputStream(jarEntry));
+            String mixin = (String) loaded.get("mixins");
+            return new SimplePaperPluginMeta(Paths.get(mixin));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/mixin-support/src/main/resources/META-INF/services/org.spongepowered.asm.service.IGlobalPropertyService
+++ b/mixin-support/src/main/resources/META-INF/services/org.spongepowered.asm.service.IGlobalPropertyService
@@ -1,0 +1,1 @@
+io.papermc.paperclip.mixin.PaperclipGlobalPropertyService

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
 rootProject.name = "paperclip"
-include("java6", "java17")
+include("java6", "java17", "mixin-support")


### PR DESCRIPTION
Highly Highly Highly WIP, requires PRs for Paper and Paperwight as well.

I'd like to start a discussion on a Mixin support for Paper. In this PR I made an initial draft of that using some of Fabric Loader and Paper plugins internals code. (License headers stay in places they should be) This whole PR does the following:
1. Adds new `mixins` field to the `paper-plugin.yml`.
2. Makes a new classloader called `MixinClassLoader` which loads the patched jar and makes bytecode modification possible.
3. Reads the mixin configuration and mixins from plugins, applies them using the mentioned classloader.

This which should be made:
1. Plugin classloaders with Mixin support. (A PR for Paper)
2. Mixin mojmap to spigot remapping. (A PR for Paperweight)

Regarding 1: My suggestion is that we can make a part of paper plugin loading system which I briefly separated in the `mixin-support` submodule as an another dependency and then depend on it in the `Paper-Server`, and do all the functionality based on this.

Regarding 2: Mixin remapping is done using its annotation processor, a gradle plugin provides mappings and other info for it, and it generates refmap files in the output jar, which later are read by mixins. Fabric has https://github.com/FabricMC/fabric-mixin-compile-extensions which supports the tiny mapping format which uses paperweight, and it is used in their gradle plugin: https://github.com/FabricMC/fabric-loom/blob/dev/1.1/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java We can make this kind of thing in the paperweight as well so users can freely use mixins with it.

P.S.
I made a test plugin with these changes using Paperweight, and ran it on the mojmap bundler jar, and it works, except there is a classloader exception in `JavaPlugin`'s constructor, which should be fixed by a PR to Paper with the support of all of this.